### PR TITLE
Count true total karma

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -116,10 +116,8 @@ window.onclick = (event) => {
 
 function mainfunc(user) {
   $.getJSON(`https://www.reddit.com/user/${user}/about.json`, (data) => {
-    commentKarma = data.data.comment_karma;
-    postKarma = data.data.link_karma;
 
-    totalKarma = commentKarma + postKarma;
+    totalKarma = data.data.total_karma;
     userName = user;
     userIcon = data.data.icon_img;
     userUrl = `https://reddit.com/u/${userName}`;


### PR DESCRIPTION
As pointed out to me, the true karma isn't showing, there are more elements to karma then just the **link karma** and the **comment karma**. There is now also the `awardee_karma` and `awarder_karma`. That is also counted with this PR.
![image](https://user-images.githubusercontent.com/29888641/97963820-07624200-1db8-11eb-8d87-3bb0cce8e5a5.png)

Huge thanks to @svobodavl for pointing this out.